### PR TITLE
refactor code and save req. blocked state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inigo.js",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
getting rid of hardcoded `GraphQL operations must contain a non-empty 'query' or a 'persistedQuery' extension.` error due to request abortion is not feasible without forking apollo-graphql.
So in order to avoid that error from popping up in `didEncounterErrors`, a small if check is needed before printing.
take for example:
``` js
plugins: [
InigoPlugin(inigoCfg),
{
requestDidStart(context) {
return {
didEncounterErrors({ errors }) {
if (!context.context.inigo.blocked) { // <---
console.log(errors)
}
}
};
}
}
],
```

---

**Stack**:
- #16
- #15
- #14
- #13 ⬅
- #12


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*