### PR TITLE
temporarily disable memory cleanup due to node bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class Query {
     );
     const output = ref.readPointer(output_ptr, 0, output_len_ptr.deref());
     const result = JSON.parse(output);
-    ffi.disposeMemory(output_ptr.deref())
+    // ffi.disposeMemory(output_ptr.deref())
     
     return result
   }
@@ -140,7 +140,7 @@ class Query {
     const output = ref.readPointer(output_ptr, 0, output_len_ptr.deref());
     const result = JSON.parse(output);
     
-    ffi.disposeMemory(output_ptr.deref())
+    // ffi.disposeMemory(output_ptr.deref())
     ffi.disposeHandle(this.#handle)
     this.#handle = 0;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inigo.js",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
bug fixed in Node 17.x
https://github.com/nodejs/node/pull/3332101

---

**Stack**:
- #16
- #15 ⬅
- #14
- #13
- #12


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*