### PR TITLE
Guard internals to modResponse

### DIFF
--- a/index.js
+++ b/index.js
@@ -663,7 +663,7 @@ class InigoRemoteDataSource extends RemoteGraphQLDataSource {
 }
 
 function modResponse(response, extended) {
-  if (extended.extensions){
+  if (extended?.extensions){
     if (!response.extensions){
       response.extensions = {}
     }
@@ -673,7 +673,7 @@ function modResponse(response, extended) {
     }
   }
 
-  if (extended.errors){
+  if (extended?.errors){
     if (!response.errors){
       response.errors = []
     }


### PR DESCRIPTION
Updates modResponse to use the safe operator to access to both extended.errors and extended.extensions.  Prevents an edge case where an apollo gateway can be initialized but not actually able to handle requests yet (for instance as part of healthchecks)